### PR TITLE
🔥 chore(deployment): remove phase 11G verification marker

### DIFF
--- a/WEB2ONION-PHASE11G.md
+++ b/WEB2ONION-PHASE11G.md
@@ -1,5 +1,0 @@
-# Web2Onion Phase 11G deployment proof
-
-This repository-only marker was created for the controlled Phase 11G deployment and rollback drill.
-
-Previous production blog commit: b72581236cb3f305f451269c9b52d1f0b00818e1


### PR DESCRIPTION
## Summary

Removes the temporary phase 11G verification marker.

This pull request will serve as the final source-originated automatic deployment proof. Deployment authorization remains disabled while pull-request checks run.