### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-07-30T16:10:37.694Z",
+  "verified_at": "2026-07-31T22:43:43.328Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16477,
-    "docker_pulls_formatted": "16,477"
+    "docker_pulls": 16517,
+    "docker_pulls_formatted": "16,517"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30670832359
Snapshot commit: `782f75059b73d31e1a6b1bae468b91507eb62ac9`
