### PR TITLE
🔒 docs(security): publish a coordinated disclosure policy

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -86,6 +86,10 @@ jobs:
             public/.well-known/nostr.json
 
           grep -Fx \
+            'Contact: https://brokenbotnet.com/security/' \
+            public/.well-known/security.txt
+
+          grep -Fx \
             'Contact: mailto:r3bo0tbx1@brokenbotnet.com' \
             public/.well-known/security.txt
 
@@ -94,11 +98,19 @@ jobs:
             public/.well-known/security.txt
 
           grep -Fx \
+            'Encryption: https://brokenbotnet.com/0xB3BD6196E1CFBFB4.asc' \
+            public/.well-known/security.txt
+
+          grep -Fx \
             'Preferred-Languages: en' \
             public/.well-known/security.txt
 
           grep -Fx \
             'Canonical: https://brokenbotnet.com/.well-known/security.txt' \
+            public/.well-known/security.txt
+
+          grep -Fx \
+            'Policy: https://brokenbotnet.com/security/' \
             public/.well-known/security.txt
 
           node <<'NODE'

--- a/content/security.md
+++ b/content/security.md
@@ -1,6 +1,9 @@
-# 🛡️ Security and Vulnerability Disclosure Policy
-
-The canonical version of this policy is published at [brokenbotnet.com/security/](https://brokenbotnet.com/security/).
+---
+title: "Security and Vulnerability Disclosure"
+date: 2026-08-02T00:00:00+09:00
+lastmod: 2026-08-02T00:00:00+09:00
+description: "How to report a vulnerability affecting brokenbotnet.com, including scope, safe-harbor terms, response targets, and coordinated disclosure."
+---
 
 ## Contact
 
@@ -23,9 +26,9 @@ Please include:
 
 This policy covers:
 
-- The current `main` branch of this repository.
+- The current `main` branch of the [brokenbotnet.github.io repository](https://github.com/BrokenBotnet/brokenbotnet.github.io).
 - The website deployed at [brokenbotnet.com](https://brokenbotnet.com/).
-- Hugo templates, first-party CSS and JavaScript, site configuration, and GitHub Actions workflows maintained in this repository.
+- Hugo templates, first-party CSS and JavaScript, site configuration, and GitHub Actions workflows maintained in that repository.
 
 Older commits, forks, local modifications, and services or software operated by third parties are outside this policy. The following projects have separate repositories and should be reported through their own security or issue channels:
 

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,7 +1,8 @@
+Contact: https://brokenbotnet.com/security/
 Contact: mailto:r3bo0tbx1@brokenbotnet.com
 Expires: 2027-06-30T23:59:59Z
 Encryption: openpgp4fpr:33727F5377D296C320AF704AB3BD6196E1CFBFB4
 Encryption: https://brokenbotnet.com/0xB3BD6196E1CFBFB4.asc
 Preferred-Languages: en
 Canonical: https://brokenbotnet.com/.well-known/security.txt
-Policy: https://github.com/BrokenBotnet/brokenbotnet.github.io/security/policy
+Policy: https://brokenbotnet.com/security/


### PR DESCRIPTION
- add first-party security contact and policy URLs
- define vulnerability scope and safe testing requirements
- provide safe harbor for compliant good-faith research
- set response targets and a 45-day disclosure window
- link the canonical OpenPGP key for encrypted reports
- clarify that no bounty, swag, or recognition is guaranteed
- validate security.txt contact, policy, and encryption fields in CI