### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-07-31T22:43:43.328Z",
+  "verified_at": "2026-08-01T19:48:40.708Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16517,
-    "docker_pulls_formatted": "16,517"
+    "docker_pulls": 16573,
+    "docker_pulls_formatted": "16,573"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30715578965
Snapshot commit: `4c01e0e01affe87e4c478fef2c1a2d46447bbf19`
