### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-01T19:48:40.708Z",
+  "verified_at": "2026-08-02T11:04:06.697Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16573,
-    "docker_pulls_formatted": "16,573"
+    "docker_pulls": 16697,
+    "docker_pulls_formatted": "16,697"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30744989903
Snapshot commit: `3cbd80d089ef11d1615e9bf8a2268ef1e3de6a6a`
