### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-02T11:04:06.697Z",
+  "verified_at": "2026-08-02T16:31:17.844Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16697,
-    "docker_pulls_formatted": "16,697"
+    "docker_pulls": 16702,
+    "docker_pulls_formatted": "16,702"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30756811473
Snapshot commit: `00127158a2c98d13b7319818a0050b711ef16c41`
