### PR TITLE
👷 ci(workflows): use the latest Ubuntu runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ jobs:
   onion:
     name: Request onion mirror rebuild
     needs: deploy
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
 


### PR DESCRIPTION
- follow GitHub's maintained Ubuntu runner image