### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-02T16:31:17.844Z",
+  "verified_at": "2026-08-02T22:32:03.775Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16702,
-    "docker_pulls_formatted": "16,702"
+    "docker_pulls": 16803,
+    "docker_pulls_formatted": "16,803"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30770301153
Snapshot commit: `53dbc51512284a4ff49f78dbfd655296696178e7`
