### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-02T22:32:03.775Z",
+  "verified_at": "2026-08-03T06:46:25.180Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16803,
-    "docker_pulls_formatted": "16,803"
+    "docker_pulls": 16823,
+    "docker_pulls_formatted": "16,823"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30791276474
Snapshot commit: `3d486648f29c00765155061c4d4c09c4a3f28703`
