### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-03T06:46:25.180Z",
+  "verified_at": "2026-08-03T12:43:53.648Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16823,
-    "docker_pulls_formatted": "16,823"
+    "docker_pulls": 16825,
+    "docker_pulls_formatted": "16,825"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30814773172
Snapshot commit: `b1cf8f90a63a307a3598cdbf8d8b6f496bf87eb8`
