### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-03T12:43:53.648Z",
+  "verified_at": "2026-08-03T17:26:53.782Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16825,
-    "docker_pulls_formatted": "16,825"
+    "docker_pulls": 16828,
+    "docker_pulls_formatted": "16,828"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30836776262
Snapshot commit: `9fa44f03d974be050902a4ea5835e03849f37850`
