### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-03T17:26:53.782Z",
+  "verified_at": "2026-08-03T22:35:55.369Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16828,
-    "docker_pulls_formatted": "16,828"
+    "docker_pulls": 16835,
+    "docker_pulls_formatted": "16,835"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30859240696
Snapshot commit: `7bb2af7e8f71a5d9c0d29d6b623c328a07949326`
