### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-03T22:35:55.369Z",
+  "verified_at": "2026-08-04T06:13:20.998Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16835,
-    "docker_pulls_formatted": "16,835"
+    "docker_pulls": 16854,
+    "docker_pulls_formatted": "16,854"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30883244674
Snapshot commit: `43608319117ff591601c5553bae03a0e6ddd8c9d`
