### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-04T06:13:20.998Z",
+  "verified_at": "2026-08-04T11:46:52.946Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16854,
-    "docker_pulls_formatted": "16,854"
+    "docker_pulls": 16855,
+    "docker_pulls_formatted": "16,855"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30906212961
Snapshot commit: `52f670fe7122ed3d1a38b3968baaf41eeffe366f`
