### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-04T11:46:52.946Z",
+  "verified_at": "2026-08-04T17:14:48.027Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16855,
-    "docker_pulls_formatted": "16,855"
+    "docker_pulls": 16876,
+    "docker_pulls_formatted": "16,876"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30932987762
Snapshot commit: `084a6fee4958718e7f273919b00997110d87d77c`
