### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-04T17:14:48.027Z",
+  "verified_at": "2026-08-04T22:39:36.772Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16876,
-    "docker_pulls_formatted": "16,876"
+    "docker_pulls": 16879,
+    "docker_pulls_formatted": "16,879"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30957205238
Snapshot commit: `e1918f6e00ed6b15a88c0461bf8a9ff9c250dc43`
