### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-04T22:39:36.772Z",
+  "verified_at": "2026-08-05T06:09:43.551Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16879,
-    "docker_pulls_formatted": "16,879"
+    "docker_pulls": 16893,
+    "docker_pulls_formatted": "16,893"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30980416024
Snapshot commit: `ae72168c6d334b7e6d935b06744c325076786b95`
