### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,5 +1,5 @@
 {
-  "verified_at": "2026-08-05T06:09:43.551Z",
+  "verified_at": "2026-08-05T06:51:07.083Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
     "docker_pulls": 16893,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30982779830
Snapshot commit: `ae82397237cb0b1043777df2c8fdae3e4f5509e1`
