### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,5 +1,5 @@
 {
-  "verified_at": "2026-08-05T06:51:07.083Z",
+  "verified_at": "2026-08-05T08:58:29.889Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
     "docker_pulls": 16893,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/30991237506
Snapshot commit: `9e47ebb06c58e156c2d20d8d46a30a951a8af4d7`
