### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,5 +1,5 @@
 {
-  "verified_at": "2026-08-05T08:58:29.889Z",
+  "verified_at": "2026-08-05T11:38:32.569Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
     "docker_pulls": 16893,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31002260898
Snapshot commit: `ad1d537c9b77d4134c97cd4f6832a108c8ef94eb`
