### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-05T11:38:32.569Z",
+  "verified_at": "2026-08-05T17:06:19.830Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16893,
-    "docker_pulls_formatted": "16,893"
+    "docker_pulls": 16914,
+    "docker_pulls_formatted": "16,914"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31028435176
Snapshot commit: `ec4ff6540610760b0712d099e4884c8e931246ed`
