### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,5 +1,5 @@
 {
-  "verified_at": "2026-08-05T17:06:19.830Z",
+  "verified_at": "2026-08-05T22:37:56.833Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
     "docker_pulls": 16914,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31053467630
Snapshot commit: `2121b4431e93f7f3c0383c22ac6991e4b75f3d6e`
