### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-05T22:37:56.833Z",
+  "verified_at": "2026-08-06T06:13:25.940Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16914,
-    "docker_pulls_formatted": "16,914"
+    "docker_pulls": 16922,
+    "docker_pulls_formatted": "16,922"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31076555360
Snapshot commit: `09a12cda8f332781e233e065fd902cf2ba3c5d78`
