### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,5 +1,5 @@
 {
-  "verified_at": "2026-08-06T06:13:25.940Z",
+  "verified_at": "2026-08-06T11:49:19.614Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
     "docker_pulls": 16922,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31098803231
Snapshot commit: `11bfd7f9f26929e45149e3a346c1dec22fec916c`
