### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-06T11:49:19.614Z",
+  "verified_at": "2026-08-07T01:04:24.515Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16922,
-    "docker_pulls_formatted": "16,922"
+    "docker_pulls": 16930,
+    "docker_pulls_formatted": "16,930"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31136807967
Snapshot commit: `0b3ee96c9c369edd37a34d724a65deb6bb6312a0`
