### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-07T01:04:24.515Z",
+  "verified_at": "2026-08-07T05:18:59.067Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16930,
-    "docker_pulls_formatted": "16,930"
+    "docker_pulls": 16931,
+    "docker_pulls_formatted": "16,931"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31150181715
Snapshot commit: `7fbb0e5712c066eaf232644af35d834ca93cf5bf`
