### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,5 +1,5 @@
 {
-  "verified_at": "2026-08-07T05:18:59.067Z",
+  "verified_at": "2026-08-07T10:29:08.420Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
     "docker_pulls": 16931,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31170242248
Snapshot commit: `4a9fa4523c9ff1393a09fa92738b6ebfaeac6f7b`
