### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-07T10:29:08.420Z",
+  "verified_at": "2026-08-07T16:28:20.091Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16931,
-    "docker_pulls_formatted": "16,931"
+    "docker_pulls": 16953,
+    "docker_pulls_formatted": "16,953"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31197707639
Snapshot commit: `3655412b862ecbc2202f279d02b01900ead2423c`
