### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-07T16:28:20.091Z",
+  "verified_at": "2026-08-07T22:08:50.356Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16953,
-    "docker_pulls_formatted": "16,953"
+    "docker_pulls": 16959,
+    "docker_pulls_formatted": "16,959"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31222745139
Snapshot commit: `3eee06e15d6d53d9059a8f9e54f6caa39cd0c474`
