### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-07T22:08:50.356Z",
+  "verified_at": "2026-08-08T04:36:47.021Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16959,
-    "docker_pulls_formatted": "16,959"
+    "docker_pulls": 16969,
+    "docker_pulls_formatted": "16,969"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31239843085
Snapshot commit: `c8334d8d4786b4b5cb5b4d713946542ac11e3933`
