### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-08T04:36:47.021Z",
+  "verified_at": "2026-08-08T05:43:45.822Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16969,
-    "docker_pulls_formatted": "16,969"
+    "docker_pulls": 16973,
+    "docker_pulls_formatted": "16,973"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31242325606
Snapshot commit: `8f614b5a192b95c584653a63eebecbc7d51196af`
