### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-08T05:43:45.822Z",
+  "verified_at": "2026-08-08T10:04:48.010Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16973,
-    "docker_pulls_formatted": "16,973"
+    "docker_pulls": 16976,
+    "docker_pulls_formatted": "16,976"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31251990579
Snapshot commit: `dbb8fd506ca1c7273e04f21f5c03fed135951074`
