### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-08T10:04:48.010Z",
+  "verified_at": "2026-08-08T15:59:07.997Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16976,
-    "docker_pulls_formatted": "16,976"
+    "docker_pulls": 16992,
+    "docker_pulls_formatted": "16,992"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31265817366
Snapshot commit: `8a51dfbdda46a369f60565b68ed6aecd18cdfcf9`
