### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-08T15:59:07.997Z",
+  "verified_at": "2026-08-08T21:58:48.488Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16992,
-    "docker_pulls_formatted": "16,992"
+    "docker_pulls": 16994,
+    "docker_pulls_formatted": "16,994"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31280599025
Snapshot commit: `235967266b92f5eaa3f2564a7f2835fb2ac8c251`
