### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-08T21:58:48.488Z",
+  "verified_at": "2026-08-09T04:48:41.269Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 16994,
-    "docker_pulls_formatted": "16,994"
+    "docker_pulls": 17006,
+    "docker_pulls_formatted": "17,006"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31295344478
Snapshot commit: `219fbfccbce1a89740b25ed2da615044f869ff25`
