### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-09T04:48:41.269Z",
+  "verified_at": "2026-08-09T10:07:25.946Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17006,
-    "docker_pulls_formatted": "17,006"
+    "docker_pulls": 17008,
+    "docker_pulls_formatted": "17,008"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31307560075
Snapshot commit: `4521611ef11d71c4cccffb47997dca0877d1da60`
