### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-09T10:07:25.946Z",
+  "verified_at": "2026-08-09T16:01:09.658Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17008,
-    "docker_pulls_formatted": "17,008"
+    "docker_pulls": 17012,
+    "docker_pulls_formatted": "17,012"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31322655242
Snapshot commit: `eeafb8e99f912a0506dc17ac636e50ed82e61c49`
