### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-09T16:01:09.658Z",
+  "verified_at": "2026-08-09T20:29:55.962Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17012,
-    "docker_pulls_formatted": "17,012"
+    "docker_pulls": 17074,
+    "docker_pulls_formatted": "17,074"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31334394644
Snapshot commit: `20c1787e8961197c5803d7858f276aaba170ad24`
