### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-09T22:01:10.617Z",
+  "verified_at": "2026-08-10T05:08:27.089Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17076,
-    "docker_pulls_formatted": "17,076"
+    "docker_pulls": 17127,
+    "docker_pulls_formatted": "17,127"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31357639934
Snapshot commit: `6029065affc6c6d94dfefe223c0549e9eb294ffa`
