### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-10T05:08:27.089Z",
+  "verified_at": "2026-08-10T10:45:55.638Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17127,
-    "docker_pulls_formatted": "17,127"
+    "docker_pulls": 17129,
+    "docker_pulls_formatted": "17,129"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31380530984
Snapshot commit: `b8ec29e539c7c4917d142b20fd82970c03864a31`
