### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-10T10:45:55.638Z",
+  "verified_at": "2026-08-10T16:26:35.844Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17129,
-    "docker_pulls_formatted": "17,129"
+    "docker_pulls": 17161,
+    "docker_pulls_formatted": "17,161"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31408950075
Snapshot commit: `eb5632a72f4e4e0ddcbad1f41fde2e8ba19d7da7`
