### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-10T16:26:35.844Z",
+  "verified_at": "2026-08-10T22:10:08.081Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17161,
-    "docker_pulls_formatted": "17,161"
+    "docker_pulls": 17163,
+    "docker_pulls_formatted": "17,163"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31437127446
Snapshot commit: `05420405525cc371c5346a648fb8abb31f3aacb1`
