### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-10T22:10:08.081Z",
+  "verified_at": "2026-08-11T04:51:44.428Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17163,
-    "docker_pulls_formatted": "17,163"
+    "docker_pulls": 17178,
+    "docker_pulls_formatted": "17,178"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31459795707
Snapshot commit: `f7d11608f760cd487079a9e4c72417fe9396b78f`
