### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-11T10:28:10.291Z",
+  "verified_at": "2026-08-11T16:28:47.684Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17199,
-    "docker_pulls_formatted": "17,199"
+    "docker_pulls": 17209,
+    "docker_pulls_formatted": "17,209"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31512590885
Snapshot commit: `ab1f0482526572a30025bd7d3d7727ae02c2c170`
