### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-11T16:28:47.684Z",
+  "verified_at": "2026-08-11T22:21:34.167Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17209,
-    "docker_pulls_formatted": "17,209"
+    "docker_pulls": 17212,
+    "docker_pulls_formatted": "17,212"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31542052697
Snapshot commit: `8b1b3c88adc22fc503fd10df79a2cced1df16bf0`
