### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-11T22:21:34.167Z",
+  "verified_at": "2026-08-12T05:16:19.336Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17212,
-    "docker_pulls_formatted": "17,212"
+    "docker_pulls": 17229,
+    "docker_pulls_formatted": "17,229"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31565985994
Snapshot commit: `451ed123029ab5e0f066029d8b6112cea0a9d689`
