### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-12T05:16:19.336Z",
+  "verified_at": "2026-08-12T10:39:02.540Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17229,
-    "docker_pulls_formatted": "17,229"
+    "docker_pulls": 17246,
+    "docker_pulls_formatted": "17,246"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31588344213
Snapshot commit: `3a8f6194274c1ea3d79a0fbf85a665e705af138b`
