### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,5 +1,5 @@
 {
-  "verified_at": "2026-08-12T10:39:02.540Z",
+  "verified_at": "2026-08-12T16:30:03.896Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
     "docker_pulls": 17246,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31617853552
Snapshot commit: `576f7b7286f802cb80ce318b0160698b494f9c29`
