### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-12T16:30:03.896Z",
+  "verified_at": "2026-08-12T22:21:28.711Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17246,
-    "docker_pulls_formatted": "17,246"
+    "docker_pulls": 17248,
+    "docker_pulls_formatted": "17,248"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31646590797
Snapshot commit: `1ac2ee9c34c7e3281f17254ec087e04b12e01fcc`
