### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-12T22:21:28.711Z",
+  "verified_at": "2026-08-13T05:20:38.975Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17248,
-    "docker_pulls_formatted": "17,248"
+    "docker_pulls": 17270,
+    "docker_pulls_formatted": "17,270"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31669990545
Snapshot commit: `100a6c895ca932ff58eba7010d4c984851ba5f87`
