### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-13T05:20:38.975Z",
+  "verified_at": "2026-08-13T10:40:26.121Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17270,
-    "docker_pulls_formatted": "17,270"
+    "docker_pulls": 17274,
+    "docker_pulls_formatted": "17,274"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31692122334
Snapshot commit: `3af122a839e3b7fcdcfd19b2965bcbcad1c56695`
