### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-13T10:40:26.121Z",
+  "verified_at": "2026-08-13T16:29:10.636Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17274,
-    "docker_pulls_formatted": "17,274"
+    "docker_pulls": 17308,
+    "docker_pulls_formatted": "17,308"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31720897133
Snapshot commit: `681cbaea773c65920c561d9987a1704e2a6df404`
