### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-13T16:29:10.636Z",
+  "verified_at": "2026-08-13T22:21:44.131Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17308,
-    "docker_pulls_formatted": "17,308"
+    "docker_pulls": 17314,
+    "docker_pulls_formatted": "17,314"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31749609349
Snapshot commit: `b05fa7c5634b3f836ecced80d4ac48a5d217a112`
