### PR TITLE
📊 chore(stats): refresh project metrics

### DIFF
--- a/data/project_stats.json
+++ b/data/project_stats.json
@@ -1,9 +1,9 @@
 {
-  "verified_at": "2026-08-13T22:21:44.131Z",
+  "verified_at": "2026-08-14T05:17:44.680Z",
   "tor_guard_relay": {
     "release": "v2.1.0",
-    "docker_pulls": 17314,
-    "docker_pulls_formatted": "17,314"
+    "docker_pulls": 17336,
+    "docker_pulls_formatted": "17,336"
   },
   "shinobi_relays": {
     "nodes": 24,


### PR DESCRIPTION
Automated refresh of the committed project statistics snapshot.

The workflow validated that only `data/project_stats.json` changed.

Source workflow: https://github.com/BrokenBotnet/brokenbotnet.github.io/actions/runs/31772533089
Snapshot commit: `c4b95a4da0b21f26400f474eb14ead23b91dc4d4`
